### PR TITLE
Adds `post` hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ First add this to your scripts section of `package.json`:
 
 ```JSON
   "scripts": {
-    "deploy": "gh-pages-deploy"
+    "deploy": "gh-pages-deploy",
+    "clean-source": "rimraf README.md src webroot package.json"
   },
 ```
 
@@ -44,6 +45,9 @@ To configure `gh-pages-deploy` all you need to do is specify a couple of things 
       "build-sass",
       "optimize-img"
     ],
+    "post": [
+      "clean-source"
+    ],
     "noprompt": false
   },
 
@@ -53,6 +57,7 @@ To configure `gh-pages-deploy` all you need to do is specify a couple of things 
 * "cname" content for CNAME file
 * "prep" an array of script names to run before pushing to github, this can be
 any script that you have declared in your "scripts" object in your `package.json`.
+* "post" an array of script names to run after "prep", but before push
 * "noprompt" if this is set to true, the prompt will be bypassed and you will never
 need to confirm the commands before deploying.
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To configure `gh-pages-deploy` all you need to do is specify a couple of things 
 * "cname" content for CNAME file
 * "prep" an array of script names to run before pushing to github, this can be
 any script that you have declared in your "scripts" object in your `package.json`.
-* "post" an array of script names to run after "prep", but before push
+* "post" an array of script names to run after "prep", but before add/commit/push
 * "noprompt" if this is set to true, the prompt will be bypassed and you will never
 need to confirm the commands before deploying.
 

--- a/index.js
+++ b/index.js
@@ -22,14 +22,21 @@ var question = {
   }
 };
 
-function getBuildCmd(prepCmds) {
-  return insert(prepCmds, [gitbranch,
-                           gitcheckout,
-                           gitreset,
-                           gitadd,
-                           gitcommit,
-                           gitpush,
-                           gitcheckmaster], 3);
+function getBuildCmd(prepCmds, postCmds) {
+  return [
+    gitbranch,
+    gitcheckout,
+    gitreset
+  ].concat(
+    prepCmds,
+    postCmds,
+    [
+      gitadd,
+      gitcommit,
+      gitpush,
+      gitcheckmaster
+    ]
+  )
 }
 
 function getPrepCmd(cfg) {
@@ -43,6 +50,18 @@ function getPrepCmd(cfg) {
 
   if (cfg.staticpath) userCmds.push("cp -r " + cfg.staticpath + "/* .");
   if (cfg.cname) userCmds.push("echo '" + cfg.cname + "' > CNAME");
+
+  return userCmds;
+}
+
+function getPostCmd(cfg) {
+  var prefix = 'npm run ';
+  var userCmds = [];
+  if (cfg.post) {
+    userCmds = cfg.post.map(function(script) {
+      return prefix + script;
+    });
+  }
 
   return userCmds;
 }
@@ -89,14 +108,6 @@ function execBuild(buildCmd, cfg) {
   });
 }
 
-function insert(toInsert, dest, index) {
-  for (var i=0; i<toInsert.length;i++) {
-    dest.splice(i+index, 0, toInsert[i]);
-  }
-
-  return dest;
-}
-
 function prepBuild (cmds) {
   var freshArr = [];
   cmds.forEach(function(cmd) {
@@ -107,7 +118,7 @@ function prepBuild (cmds) {
 }
 
 function getFullCmd(cfg) {
-  return prepBuild(getBuildCmd(getPrepCmd(cfg)));
+  return prepBuild(getBuildCmd(getPrepCmd(cfg), getPostCmd(cfg)));
 }
 
 module.exports = {


### PR DESCRIPTION
Resolves #17

This adds `post` hooks. I made an [example project](https://github.com/konsumer/test-gh) that is deployed this way (so you can see [gh-pages](https://github.com/konsumer/test-gh/tree/gh-pages).

It's not perfect. If post deletes .gitignore it will check in too much stuff, or if it messes with package.json/node_modules, it will make scripts not work correctly in gh-pages.

I think the best way to resolve this would be a flow something like this:

```
checkout gh-pages to NEWDIR
prepCmds
cp STATIC/* to NEWDIR
cd NEWDIR
postCmds
 ```

And maybe in this case `postCmds` should not be `npm run` based (like node_modules/.bin will be in path, so just run `rimraf README.md src webroot package.json .gitignore node_modules` directly)

This PR solves my use-case, and maybe gives some direction for the future.

